### PR TITLE
Fix CI gate job passing when dependent jobs fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,5 +211,5 @@ jobs:
     needs: [build, scan-ruby, scan-js, lint, zeitwerk, test]
     runs-on: ubuntu-slim
     steps:
-      - if: ${{ !success() }}
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- CI gate job passing when dependent jobs fail (`success()` at step level doesn't check `needs` context)
 - API key toggle not working (`td code { display: inline-block }` overrode `hidden` attribute)
 - Full API key truncated when revealed (scoped `max-width`/`overflow` to truncated element only)
 - Auto-select full API key text on reveal for easy copy-paste


### PR DESCRIPTION
## Summary

- Step-level `success()` checks previous steps in the current job, not the `needs` context — so the gate always passed
- Replace with `contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')` to properly detect upstream failures