### PR TITLE
Pin Playwright version in browser container, revert npm bump

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ SITE_PASSWORD=lizard
 # Docker image registry (used by docker-bake.hcl)
 IMAGE_NAME=registry.example.com/lizard
 
+# Playwright version — keep in sync with Gemfile (playwright-ruby-client) and package.json
+PLAYWRIGHT_VERSION=1.58.0
+
 # Lizard test reporting
 LIZARD_API_KEY=
 LIZARD_URL=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Delete test run uses Turbo Stream for in-place row removal + flash (replaces `_top` full-page reload)
 - Sign-in page not respecting dark mode (hardcoded light colors, no `prefers-color-scheme` media query)
 - Failed login rendering sign-in form inside application layout (`layout false` missing `:create` action)
+- Playwright browser container silently fetching latest version via `npx` (pin version in `.env`, revert npm bump to match Ruby client)
 
 ### Security
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
 
   browser:
     # See README.md "Playwright Versions" for version alignment info
-    image: mcr.microsoft.com/playwright:v1.58.0-jammy
+    image: mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-jammy
     profiles: [test]
-    command: npx playwright run-server --port 3001 --host 0.0.0.0
+    command: npx playwright@${PLAYWRIGHT_VERSION} run-server --port 3001 --host 0.0.0.0
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:3001"]
       interval: 5s

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "playwright": "^1.59.1"
+        "playwright": "^1.58.2"
       }
     },
     "node_modules/fsevents": {
@@ -24,13 +24,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.58.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "playwright": "see README.md 'Playwright Versions'",
-    "playwright": "^1.59.1"
+    "playwright": "^1.58.2"
   }
 }


### PR DESCRIPTION
## Summary

- Browser container's `npx playwright run-server` was fetching **latest** from npm (no local install in the image), silently breaking when 1.59.1 was published against `v1.58.0-jammy`'s `chromium-1208` binaries
- Add `PLAYWRIGHT_VERSION` to `.env` / `.env.example`, reference in `docker-compose.yml` for both image tag and `npx` pin
- Revert npm playwright bump to 1.58.2 (`playwright-ruby-client` 1.59.x doesn't exist yet, caused `Missing type Debugger` crash in CI)