### PR TITLE
Bump playwright to 1.59 (JS, Ruby client, Docker)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ SITE_PASSWORD=lizard
 IMAGE_NAME=registry.example.com/lizard
 
 # Playwright version — keep in sync with Gemfile (playwright-ruby-client) and package.json
-PLAYWRIGHT_VERSION=1.58.0
+PLAYWRIGHT_VERSION=1.59.1
 
 # Lizard test reporting
 LIZARD_API_KEY=

--- a/Gemfile
+++ b/Gemfile
@@ -63,7 +63,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "capybara-playwright-driver"
-  gem "playwright-ruby-client", "1.58.1" # see README.md "Playwright Versions"
+  gem "playwright-ruby-client", "1.59.0" # see README.md "Playwright Versions"
   gem "json_schemer", require: false
   gem "simplecov", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0317)
+    mime-types-data (3.2026.0407)
     mini_mime (1.1.5)
     minitest (6.0.2)
       drb (~> 2.0)
@@ -206,7 +206,7 @@ GEM
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
-    playwright-ruby-client (1.58.1)
+    playwright-ruby-client (1.59.0)
       base64
       concurrent-ruby (>= 1.1.6)
       mime-types (>= 3.0)
@@ -433,7 +433,7 @@ DEPENDENCIES
   lizard (~> 0.2.0)!
   pagy (~> 43.5)
   pg (~> 1.6)
-  playwright-ruby-client (= 1.58.1)
+  playwright-ruby-client (= 1.59.0)
   propshaft
   puma (>= 5.0)
   rack-attack

--- a/README.md
+++ b/README.md
@@ -107,12 +107,11 @@ System tests use Playwright. These versions should align when possible:
 
 | Component              | Version | Location           |
 |------------------------|---------|--------------------|
-| playwright-ruby-client | 1.57.1  | Gemfile            |
-| playwright (npm)       | 1.57.0  | package.json       |
-| playwright (docker)    | 1.58.0  | docker-compose.yml |
+| playwright-ruby-client | 1.59.0  | Gemfile            |
+| playwright (npm)       | 1.59.1  | package.json       |
+| playwright (docker)    | 1.59.1  | docker-compose.yml |
 
-Currently mismatched because gem 1.57.x requires browser revision 1208 which
-ships with Playwright 1.58.0. Future releases should align all three.
+All three components are aligned on the 1.59.x release.
 
 ## Deployment
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "playwright": "^1.58.2"
+        "playwright": "^1.59.1"
       }
     },
     "node_modules/fsevents": {
@@ -24,13 +24,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -43,9 +43,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
     "playwright": "see README.md 'Playwright Versions'",
-    "playwright": "^1.58.2"
+    "playwright": "^1.59.1"
   }
 }


### PR DESCRIPTION
## Summary
- Bump `playwright` (JS) from 1.58.2 to 1.59.1
- Bump `playwright-ruby-client` from 1.58.1 to 1.59.0
- Bump docker `PLAYWRIGHT_VERSION` from 1.58.0 to 1.59.1
- Update README version table (all three now aligned on 1.59.x)

Combined because these packages must stay version-aligned — the JS package runs in the browser container and the Ruby client communicates with it via a shared protocol. Merging them separately caused CI failures in #164 and #169.

Closes #164
Closes #169