### PR TITLE
Fix deploy workflow failing on no-op deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,4 +104,12 @@ jobs:
         run: ssh-keyscan -p ${{ secrets.DOKKU_PORT }} -H ${{ secrets.DOKKU_HOST }} >> ~/.ssh/known_hosts
 
       - name: Deploy to Dokku
-        run: ssh -p ${{ secrets.DOKKU_PORT }} dokku@${{ secrets.DOKKU_HOST }} git:from-image lizard ${{ env.IMAGE_NAME }}:${{ env.GIT_SHA_SHORT }}
+        run: |
+          output=$(ssh -p ${{ secrets.DOKKU_PORT }} dokku@${{ secrets.DOKKU_HOST }} git:from-image lizard ${{ env.IMAGE_NAME }}:${{ env.GIT_SHA_SHORT }} 2>&1) && exit 0
+          if echo "$output" | grep -q "No changes detected"; then
+            echo "No changes detected, skipping deploy"
+            exit 0
+          else
+            echo "$output"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Deploy workflow failing when Dokku detects no image changes ("No changes detected, skipping git commit")
 - CI gate job passing when dependent jobs fail (`success()` at step level doesn't check `needs` context)
 - API key toggle not working (`td code { display: inline-block }` overrode `hidden` attribute)
 - Full API key truncated when revealed (scoped `max-width`/`overflow` to truncated element only)


### PR DESCRIPTION
## Summary

- When the Docker image content is unchanged, Dokku's `git:from-image` exits non-zero with "No changes detected, skipping git commit." — this caused the deploy job to fail
- The deploy step now captures the output and treats "No changes detected" as a success while still failing on real errors