### PR TITLE
Stream deploy output to logs via tee

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,11 +105,9 @@ jobs:
 
       - name: Deploy to Dokku
         run: |
-          output=$(ssh -p ${{ secrets.DOKKU_PORT }} dokku@${{ secrets.DOKKU_HOST }} git:from-image lizard ${{ env.IMAGE_NAME }}:${{ env.GIT_SHA_SHORT }} 2>&1) && exit 0
+          output=$(ssh -p ${{ secrets.DOKKU_PORT }} dokku@${{ secrets.DOKKU_HOST }} git:from-image lizard ${{ env.IMAGE_NAME }}:${{ env.GIT_SHA_SHORT }} 2>&1 | tee /dev/stderr) && exit 0
           if echo "$output" | grep -q "No changes detected"; then
-            echo "No changes detected, skipping deploy"
             exit 0
           else
-            echo "$output"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Use `tee /dev/stderr` to stream Dokku deploy output to logs in real time while still capturing it for the no-changes check
- Removes the now-redundant manual `echo` calls since `tee` handles output display

Depends on #173