### PR TITLE
Capitalize CI job names and rename gate job to merge_ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -71,6 +72,7 @@ jobs:
         run: bin/importmap audit
 
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -88,6 +90,7 @@ jobs:
         run: bin/standardrb --format github
 
   zeitwerk:
+    name: Zeitwerk
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -105,6 +108,7 @@ jobs:
         run: bin/rails zeitwerk:check
 
   test:
+    name: Test
     runs-on: ubuntu-latest
 
     env:
@@ -206,9 +210,10 @@ jobs:
             ${{ github.workspace }}/tmp/capybara/videos
           if-no-files-found: ignore
 
-  ci:
+  merge_ready:
+    name: Merge Ready
     if: always()
-    needs: [build, scan-ruby, scan-js, lint, zeitwerk, test]
+    needs: [test, build, lint, zeitwerk, scan-ruby, scan-js]
     runs-on: ubuntu-slim
     steps:
       - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Refactored vanilla JS (onclick handlers, inline scripts) to Stimulus controllers for API key toggle and metrics chart
 - Used full Ruby image for dev Docker stage
 - Sign-in page now renders within app layout (removes standalone HTML doc, reuses Simple.css + shared flash handling)
+- Capitalized CI job display names and renamed gate job from `ci` to `merge_ready` (Merge Ready)
 
 ### Fixed
 


### PR DESCRIPTION
## Summary
- Add explicit `name:` to all CI jobs (Build, Test, Lint, Zeitwerk)
- Rename gate job from `ci` to `merge_ready` (displays as "Merge Ready")
- Reorder `needs` array to list `test` first