### PR TITLE
Inherit Api::V1::TestRunsController from ActionController::API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Used full Ruby image for dev Docker stage
 - Sign-in page now renders within app layout (removes standalone HTML doc, reuses Simple.css + shared flash handling)
 - Capitalized CI job display names and renamed gate job from `ci` to `merge_ready` (Merge Ready)
+- `Api::V1::TestRunsController` inherits from `ActionController::API` instead of `ApplicationController` (slimmer base; drops the now-unnecessary `skip_before_action :verify_authenticity_token`)
 
 ### Fixed
 

--- a/app/controllers/api/v1/test_runs_controller.rb
+++ b/app/controllers/api/v1/test_runs_controller.rb
@@ -1,7 +1,6 @@
 module Api
   module V1
-    class TestRunsController < ApplicationController
-      skip_before_action :verify_authenticity_token
+    class TestRunsController < ActionController::API
       before_action :authenticate_project!
 
       def create
@@ -18,6 +17,7 @@ module Api
         api_key = auth_header.sub(/^Bearer\s+/, "")
         return render json: {error: "Invalid Authorization format"}, status: :unauthorized if api_key == auth_header
 
+        # TODO: use ActiveSupport::SecurityUtils.secure_compare if api_key entropy is ever reduced — current 256-bit hex makes timing attacks impractical
         @project = Project.find_by!(api_key: api_key)
       rescue ActiveRecord::RecordNotFound
         render json: {error: "Invalid API key"}, status: :unauthorized


### PR DESCRIPTION
## Summary

- Switch `Api::V1::TestRunsController` from `ApplicationController` to `ActionController::API`. `ActionController::API` omits the session/cookie/CSRF middleware stack that's loaded by `ActionController::Base` (and inherited via `ApplicationController`) — none of it is reachable on a JSON-only endpoint, so the slimmer base is the correct fit and shortens the per-request middleware chain.
- Remove the now-redundant `skip_before_action :verify_authenticity_token`. With `ActionController::API` there is no `verify_authenticity_token` callback to skip — CSRF protection was never registered in the first place. Removing the line on the *old* base would have broken every API POST; it's only safe to drop in the same change that swaps the base class.
- Add a TODO noting that `ActiveSupport::SecurityUtils.secure_compare` is unnecessary while API keys are 256-bit hex (`SecureRandom.hex(32)`). At that entropy a timing side-channel still leaves an attacker with ~2¹²⁸ guesses on average; the helper would only be warranted if the key format were ever shortened.
- CHANGELOG: entry under `[Unreleased]` → `Changed`.
