### PR TITLE
Fix DB pool metric gaps from connected? guard

### DIFF
--- a/config/initializers/yabeda.rb
+++ b/config/initializers/yabeda.rb
@@ -52,14 +52,12 @@ Yabeda.configure do
     ruby_heap_free_slots.set({}, gc[:heap_free_slots])
 
     # DB pool
-    if defined?(ActiveRecord::Base) && ActiveRecord::Base.connected?
-      pool_stat = ActiveRecord::Base.connection_pool.stat
-      rails_db_pool_size.set({}, pool_stat[:size])
-      rails_db_pool_connections.set({}, pool_stat[:connections])
-      rails_db_pool_busy.set({}, pool_stat[:busy])
-      rails_db_pool_idle.set({}, pool_stat[:idle])
-      rails_db_pool_waiting.set({}, pool_stat[:waiting])
-    end
+    pool_stat = ActiveRecord::Base.connection_pool.stat
+    rails_db_pool_size.set({}, pool_stat[:size])
+    rails_db_pool_connections.set({}, pool_stat[:connections])
+    rails_db_pool_busy.set({}, pool_stat[:busy])
+    rails_db_pool_idle.set({}, pool_stat[:idle])
+    rails_db_pool_waiting.set({}, pool_stat[:waiting])
   end
 end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   db:
     image: postgres:18-alpine
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql
     environment:
       POSTGRES_USER: lizard
       POSTGRES_PASSWORD: lizard

--- a/spec/requests/metrics_spec.rb
+++ b/spec/requests/metrics_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe "GET /metrics", type: :request do
+  it "returns Prometheus exposition successfully" do
+    get "/metrics"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to include("text/plain")
+  end
+
+  it "exposes DB pool gauges" do
+    get "/metrics"
+
+    expect(response.body).to include("rails_db_pool_size")
+    expect(response.body).to include("rails_db_pool_busy")
+    expect(response.body).to include("rails_db_pool_idle")
+  end
+
+  it "exposes Ruby GC and process gauges" do
+    get "/metrics"
+
+    expect(response.body).to include("ruby_gc_count")
+    expect(response.body).to include("ruby_heap_live_slots")
+    expect(response.body).to include("process_resident_memory_bytes")
+  end
+
+  it "bypasses site auth" do
+    get "/metrics"
+
+    expect(response).not_to redirect_to("/sign_in")
+  end
+end


### PR DESCRIPTION
## Summary
- Remove `ActiveRecord::Base.connected?` guard from yabeda DB pool collect block. The guard is per-thread; Prometheus scrape threads rarely run DB queries, so the guard returned `false` and skipped the block, leaving `rails_db_pool_*` gauges with gaps after Puma worker restarts. `connection_pool.stat` is safe to call before any connection is established.
- Add `/metrics` request spec — covers initializer crashes, missing gauges, and auth bypass regressions.
- Update `docker-compose.yml` postgres mount to the v18+ parent-directory layout so the dev DB starts on current image.

## Background
Re-attempt of closed PR #167. Grafana confirms the bug: the "DB Connection Pool" panel on the Rails dashboard shows dashed-line gaps in `size` (a static config value that should be a flat 5) aligned with worker restart events.