### PR TITLE
Use playwright install-deps to avoid fragile output parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install --no-install-recommends --yes build-essential libyaml-dev pkg-config
 
       - name: Install Playwright system dependencies
-        run: |
-          PLAYWRIGHT_INSTALL_CMD=$(npx playwright install --dry-run --with-deps ${{ env.PLAYWRIGHT_BROWSERS }} | head -1 | sed 's/^sudo -- sh -c "//' | sed 's/"$//')
-          sudo sh -c "$PLAYWRIGHT_INSTALL_CMD"
+        run: sudo npx playwright install-deps ${{ env.PLAYWRIGHT_BROWSERS }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary
- Replace fragile `npx playwright install --dry-run` output parsing with the documented `playwright install-deps` subcommand
- Unblocks #195 (Playwright 1.60.0 bump) — the 1.60.0 release reformatted dry-run output so the extracted command contains an unescaped `(`, causing `sh: 1: Syntax error: "(" unexpected` in the CI Test job

## Root cause
The previous step did:
```
PLAYWRIGHT_INSTALL_CMD=\$(npx playwright install --dry-run --with-deps chromium | head -1 | sed ...)
sudo sh -c "\$PLAYWRIGHT_INSTALL_CMD"
```
This scrapes a non-contract output line. Playwright 1.60.0 changed that line so the extracted string includes characters that don't parse in plain `sh`. `playwright install-deps` is the documented CLI for "install system packages but not browsers" — exactly what this step needs, since the next step uses an actions/cache for the browser binaries.

## Test plan
- [ ] CI Test job passes on this PR (was failing on #195 with shell syntax error)
- [ ] After merge, rebase #195 against main and confirm its CI goes green