### PR TITLE
Add project documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## About
+
+Rails 8 app for tracking test run metrics across projects. Projects have auto-generated API keys; test runs submitted via API.
+
+## Commands
+
+All commands run via docker compose:
+
+```bash
+# Tests — run all
+docker compose run --rm app bin/rspec                    # unit/controller (excludes system tests)
+docker compose run --rm test                             # system tests only (default CMD: bin/rspec-all)
+docker compose run --rm test bin/rspec-all               # everything (unit + controller + system)
+
+# Tests — rake tasks
+docker compose run --rm app bin/rails spec               # unit/controller (reads .rspec, excludes system)
+docker compose run --rm test bin/rails spec:system       # system tests only (overrides .rspec exclusion)
+
+# Tests — targeted
+docker compose run --rm app bin/rspec spec/models                      # single directory
+docker compose run --rm app bin/rspec spec/models/project_spec.rb:10   # single test/line
+docker compose run --rm test bin/rspec-all spec/system/projects_spec.rb  # single system spec file
+
+# Notes:
+# - .rspec has --tag ~type:system → bin/rspec always skips system tests
+# - bin/rspec-all uses .rspec_all (no exclusions) → includes system tests
+# - System tests (:js) need the `test` service for the Playwright browser container
+# - Non-JS system tests use rack_test driver (fast, no browser needed)
+# - `app` service lacks HOSTNAME/browser deps, so :js tests fail there
+
+# Lint
+docker compose run --rm app bin/standardrb          # check
+docker compose run --rm app bin/standardrb --fix    # autofix
+
+# Other
+docker compose run --rm app bin/brakeman --no-pager  # security scan
+docker compose run --rm app bin/importmap audit      # JS dependency audit
+docker compose run --rm app bin/rails zeitwerk:check # autoload check
+
+# Load tests (k6 — runs natively, not in compose)
+k6 run k6/scenarios/smoke.js -e BASE_URL=https://lizard.dokku.djbender.com -e SITE_PASSWORD=...
+# Scenarios: smoke (sanity), load (typical), stress (find limits), spike (burst).
+# See k6/README.md for env vars + structure.
+```
+
+## Docker
+
+- Services: `app`, `db`, `browser`, `test`, `pghero`, `prometheus`
+- Bundle cache in `bundle_cache` volume
+- System tests use remote Playwright browser container
+- Profiles: `test` (browser, test), `monitoring` (pghero, prometheus)
+
+```bash
+docker compose up -d                          # db + app only
+docker compose --profile test up -d           # + browser + test
+docker compose --profile monitoring up -d     # + pghero + prometheus
+```
+
+### Stale gem warnings ("missing extensions")
+
+```bash
+docker compose run --rm app bundle clean --force
+```
+
+Removes gems not in current Gemfile.lock. Use `bundle pristine` to recompile native extensions instead.
+
+## Architecture
+
+**Models**: `Project` has_many `TestRun`. Projects auto-generate 64-char hex API key on create.
+
+**Auth**: Site-wide password auth via `SITE_PASSWORD` env var. API endpoints (`/api/`) bypass auth. Sessions expire after 24h.
+
+**API**: `POST /api/v1/test_runs` with `api_key` + test run data (ran_at, duration, passed, failed, skipped).
+
+**Testing**: Capybara + Playwright for system tests. `js: true` metadata triggers Playwright driver. Videos saved on failure to `tmp/capybara/videos/`.
+
+## Monitoring
+
+`/metrics` endpoint exposes Prometheus metrics (yabeda). Bypasses site auth. See `../prometheus/prometheus-dokku-setup.md` for production deployment.
+
+## Git Hooks
+
+Run `./script/install-git-hooks` to install pre-commit (standardrb --fix) and pre-push (standardrb check) hooks.
+
+## Agents
+
+This repo has engineering agent support files in `docs/agents/`:
+
+- `docs/agents/issue-tracker.md` — GitHub issue tracker config (repo: `djbender/lizard`)
+- `docs/agents/triage-labels.md` — label vocabulary for issue triage
+- `docs/agents/domain.md` — domain model: Project, TestRun, API, auth, metrics
+
+These files are read by engineering skills (triage, to-issues, to-prd, review, implement, etc.) to understand the project's issue tracking workflow and domain language. Do not edit them manually unless switching issue trackers or restarting setup.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,38 @@
+# ADRs: Lizard
+
+## Layout
+
+Architecture Decision Records go in this directory. Each ADR is a separate markdown file.
+
+### Naming convention
+
+`NNNN-title-with-hyphens.md`
+
+Where `NNNN` is a zero-padded sequential number (0001, 0002, ...).
+
+### Template
+
+```markdown
+# NNNN: Title
+
+## Context
+What is the issue that this ADR addresses? What background do we need?
+
+## Decision
+What is the change that we're proposing to do or have done?
+
+## Consequences
+What becomes easier or more difficult to do because of this change?
+```
+
+## Rules
+
+- Write an ADR when you make a decision that is likely to be relevant to future agents or human contributors.
+- An ADR is needed for: technology choices, architectural patterns, API design decisions, data model changes, security decisions.
+- An ADR is NOT needed for: routine bug fixes, dependency bumps, configuration tweaks.
+- Reference existing ADRs when a decision builds on or conflicts with a prior one (`See also: [NNNN-title](./NNNN-title.md)`).
+- Keep ADRs brief. 3-5 sections, ~200-500 words each.
+
+## Existing ADRs
+
+_(none yet — first ADR goes here as `0001-...`)_

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,88 @@
+# Domain: Lizard — Test Run Metrics Tracker
+
+## What it is
+
+Lizard is a Rails 8 application that tracks test run metrics across projects.
+Projects submit test run data via a public API; Lizard stores and exposes
+metrics for monitoring and analysis.
+
+## Core concepts
+
+### Project
+
+A registered consumer of the API. Each project gets a 64-character hex API key
+on creation. Projects have a name and a list of test runs.
+
+**Model**: `Project`
+- `id` — primary key
+- `name` — human identifier
+- `api_key` — 64-char hex string, auto-generated, unique
+- `created_at`, `updated_at`
+
+**Model**: `TestRun`
+- `id` — primary key
+- `project_id` — foreign key to Project
+- `ran_at` — timestamp of when the test run occurred
+- `duration` — total duration in seconds
+- `passed` — integer count of passed tests
+- `failed` — integer count of failed tests
+- `skipped` — integer count of skipped tests
+- `created_at`, `updated_at`
+
+### Test Run
+
+A single execution of a project's test suite. Submitted via `POST /api/v1/test_runs`
+with `api_key` and test run data.
+
+### API
+
+Public endpoints under `/api/` bypass site auth.
+
+- `POST /api/v1/test_runs` — submit a test run (requires `api_key`)
+
+### Auth
+
+Site-wide password auth via `SITE_PASSWORD` environment variable. All non-API
+routes require login. Sessions expire after 24 hours.
+
+### Metrics
+
+`/metrics` endpoint exposes Prometheus metrics via Yabeda. Bypasses site auth.
+Used by Prometheus for monitoring.
+
+## Architecture notes
+
+- Rails 8 application
+- Docker Compose for development: `app`, `db`, `browser`, `test`, `pghero`, `prometheus`
+- PostgreSQL database
+- Importmap for JS
+- StandardRB for linting
+- RSpec for testing (unit + system with Playwright)
+
+## API Contract
+
+`POST /api/v1/test_runs`
+
+**Request body:**
+```json
+{
+  "api_key": "string (required)",
+  "test_run": {
+    "ran_at": "ISO 8601 timestamp (required)",
+    "duration": "float (required)",
+    "passed": "integer (default: 0)",
+    "failed": "integer (default: 0)",
+    "skipped": "integer (default: 0)"
+  }
+}
+```
+
+**Response:** `201 Created` with the created TestRun JSON, or `401/422` on error.
+
+## Key files
+
+- `app/models/project.rb` — Project model
+- `app/models/test_run.rb` — TestRun model
+- `app/controllers/api/v1/test_runs_controller.rb` — API endpoint
+- `config/routes.rb` — route definitions
+- `Gemfile` — dependencies

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,35 @@
+# Issue Tracker: GitHub
+
+## Type
+
+GitHub repository issues.
+
+## Location
+
+- Repository: `djbender/lizard`
+- Remote: `origin` → `git@github.com:djbender/lizard.git`
+- Also proxied via `dokku` → `dokku@djbender.com:lizard` (deploy target, not issue tracker)
+
+## How agents should interact
+
+Agents use the `github_*` tools to interact with the GitHub issue tracker:
+
+- `github_search_issues` / `github_list_issues` — find existing issues
+- `github_issue_write` — create new issues or update existing ones
+- `github_get_file_contents` — read this file and triage-labels.md
+- `github_list_labels` / `github_get_label` — read/write labels
+
+## Issue structure
+
+Issues use labels for triage state and category (see `triage-labels.md`).
+Labels are defined in the repository at `.github/labels.yml` or created via the GitHub UI — agents should check existing labels before creating new ones.
+
+## Ticket workflow
+
+1. **Backlog** — issue created, unassigned, no milestone
+2. **In Sprint** — assigned to a milestone, has an assignee
+3. **In Progress** — PR opened referencing the issue (`#issue_number`)
+4. **Review** — PR open, awaiting review
+5. **Done** — PR merged, issue auto-closed
+
+Agents creating issues should start them at **Backlog** (no milestone, no assignee).

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,39 @@
+# Triage Labels
+
+## State labels
+
+| Label | Meaning |
+|-------|---------|
+| `triage:backlog` | Issue acknowledged, not yet scheduled |
+| `triage:in-sprint` | Issue assigned to a milestone/sprint |
+| `triage:in-progress` | Work has started (PR linked) |
+| `triage:review` | PR open, awaiting review |
+| `triage:done` | Closed by merge (usually auto) |
+
+## Category labels
+
+| Label | Meaning |
+|-------|---------|
+| `type:bug` | Something is broken |
+| `type:feature` | New functionality |
+| `type:enhancement` | Improvement to existing functionality |
+| `type:docs` | Documentation change |
+| `type:refactor` | Code restructuring, no behavior change |
+| `type:chore` | Maintenance, deps, CI, tooling |
+| `type:performance` | Speed or resource optimization |
+
+## Priority labels
+
+| Label | Meaning |
+|-------|---------|
+| `priority:p0` | Critical — stop everything, fix now |
+| `priority:p1` | High — fix this sprint |
+| `priority:p2` | Medium — schedule when convenient |
+| `priority:p3` | Low — nice to have |
+
+## Usage rules
+
+- Assign **one** state label, **one** category label, and **one** priority label to every new issue.
+- State labels are mutually exclusive; category and priority are not.
+- When a PR is merged and closes an issue, the state label is removed automatically by GitHub.
+- Do not create new labels without checking existing ones first.


### PR DESCRIPTION
## Summary

Adds comprehensive project documentation for developers and engineering agents:

- CLAUDE.md — Developer guide with Docker setup, test commands, architecture overview
- docs/adr/ — Architecture Decision Records template and structure
- docs/agents/ — Domain model, GitHub issue tracker config, and triage labels for agent workflows